### PR TITLE
Remove the below part of activesupport dependency. Support Rails5.1

### DIFF
--- a/simon_says.gemspec
+++ b/simon_says.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 4.0", "< 5.1"
+  spec.add_dependency "activesupport", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
```
Bundler could not find compatible versions for gem "activesupport":
  In snapshot (Gemfile.lock):
    activesupport (= 5.1.0)

  In Gemfile:
    pundit (~> 1.1) was resolved to 1.1.0, which depends on
      activesupport (>= 3.0.0)

    simon_says (~> 0.1.5) was resolved to 0.1.5, which depends on
      activesupport (< 5.1, >= 4.0)```